### PR TITLE
fix(fill-the-blanks): respect ignore case config on review

### DIFF
--- a/fill-the-blanks/src/handler.py
+++ b/fill-the-blanks/src/handler.py
@@ -9,6 +9,7 @@ import os
 import re
 from bs4 import BeautifulSoup
 import html
+from .config import ConfigService, ConfigKey
 
 try:
     from anki.utils import stripHTML
@@ -223,6 +224,8 @@ class TypeClozeHander:
 
     def format_field_result(self, given: str, expected: str):
         if given.strip() == expected.strip():
+            return "<span class='cloze st-ok'>%s</span>" % expected
+        if ConfigService.read(ConfigKey.IGNORE_CASE, bool) and given.strip().lower() == expected.strip().lower():
             return "<span class='cloze st-ok'>%s</span>" % expected
         return "<span class='cloze st-expected'>%s</span> <span class='cloze st-error'>(%s)</span>" % (expected, given)
 


### PR DESCRIPTION
Hello! Thanks for your work on this excellent plugin, I use it almost every day.

The new feedback on review feature is super useful, though most of the time I don't care about casing so I have that switched off in the config. At the moment though it doesn't respect that e.g.

![image](https://user-images.githubusercontent.com/12831300/110241112-01879380-7f47-11eb-9ac5-5ca8e67e5d6a.png)

I'm not a python dev and nor have I worked with Anki plugins before, but I took a quick look at the code and this is my best guess as to how to fix it. Feel free to close this PR if I'm way off though!