### PR TITLE
fix formatting conflict with syntax highlighting plugin

### DIFF
--- a/fill-the-blanks/src/handler.py
+++ b/fill-the-blanks/src/handler.py
@@ -155,9 +155,8 @@ class TypeClozeHander:
         for idx, field in enumerate(fieldsCtx.entries):
             (val, hint) = field.value, field.hint
             item = """<input type="hidden" id="ansval%d" value="%s" />""" % (idx, val.replace('"', '&quot;'))
-            item = item + """<input type="text" id="typeans{0}" placeholder="{1}" class="ftb" style="width: {2}em" />
-<script type="text/javascript">
-    setUpFillBlankListener($('#ansval{0}').val(), {0})
+            item = item + """<input type="text" id="typeans{0}" placeholder="{1}"
+class="ftb" style="width: {2}em" /><script type="text/javascript">setUpFillBlankListener($('#ansval{0}').val(), {0})
 </script>""".format(idx, hint, self._getInputLength(hint, val))
             res = res.replace('[...]', item, 1)
 


### PR DESCRIPTION
Hello again!

I use the `fill-the-blanks` plugin in conjunction with the [Syntax Highlighting for Code](https://ankiweb.net/shared/info/1463041493) plugin, which all worked fine until the latest update.

Somehow they now conflict with each other to give me this:

![image](https://user-images.githubusercontent.com/12831300/127745421-1cedfaee-2272-4a8b-926e-757c22aa0364.png)

When it should look like this:
![image](https://user-images.githubusercontent.com/12831300/127745374-ebee5857-d2a7-441f-a828-9d16c5edca47.png)

I don't understand why, but for some reason the line breaks in this bit of code needs to come at a very particular place 🤷 (I'm not really sure how to properly debug this kind of thing other than randomly hacking at the code and opening and closing Anki until it works!)