### PR TITLE
fill the blanks - adding urlparse on the fields rendered

### DIFF
--- a/fill-the-blanks/src/handler.py
+++ b/fill-the-blanks/src/handler.py
@@ -207,9 +207,9 @@ class="ftb" style="width: {2}em" /><script type="text/javascript">setUpFillBlank
         result = buf
         for index, field in enumerate(ctx.entries):
             cor = self.original_clear_correct_value(field.value)
-            given = ctx.answers[index] if ctx.answers and len(ctx.answers) == len(ctx.entries) else "None"
+            given = html.escape(ctx.answers[index]) if ctx.answers and len(ctx.answers) == len(ctx.entries) else "None"
             field_res = self.format_field_result(given, cor)
-            result = result.replace('<span class=cloze>%s</span>' % field.value, field_res, 1)
+            result = result.replace('<span class=cloze>%s</span>' % html.escape(field.value), field_res, 1)
 
         # from original
         def repl(match):
@@ -241,6 +241,7 @@ class="ftb" style="width: {2}em" /><script type="text/javascript">setUpFillBlank
         cor = html.unescape(cor)
         cor = cor.replace("\xa0", " ")
         cor = cor.strip()
+        cor = html.escape(cor)
         return cor
 
     def _getTypedAnswer(self) -> None:


### PR DESCRIPTION
First of all, thank you for the add-on! I loved it!
Super useful for me to study computer languages.

I get a problem and this PR solved it.

Bug description:
1. create a new cloze card with one cloze field, containing & or < (or even other character handled by default in HTML)
2. Try to learn the card. fill the fields.
3. The visualization was not rendered correctly.

| step 1 | step 2 | step 3 | with all fields correctly filled |
| --- | --- | --- | ---- |
| ![image](https://user-images.githubusercontent.com/5148153/150705392-6a44f0aa-18b5-417d-a3ee-ab4167f566fe.png) | ![image](https://user-images.githubusercontent.com/5148153/150705416-116f57c1-0719-4ef2-8a1b-979d32ff1285.png) | ![image](https://user-images.githubusercontent.com/5148153/150705424-29d9a555-3747-4c36-a5e3-5c6bf1bd824b.png) | ![image](https://user-images.githubusercontent.com/5148153/150705605-d95988f0-72ac-45d5-9d4e-df588bf7e1d6.png) |



This PR fixes this. The following behaviour is the new one

| step 1 | step 2 | step 3 | with all fields correctly filled |
| --- | --- | --- | ---- |
| ![image](https://user-images.githubusercontent.com/5148153/150705485-5702d7de-104f-4325-87f7-bfcfd5d71b20.png) | ![image](https://user-images.githubusercontent.com/5148153/150705499-53cc47c5-789c-47d5-902b-b031f1939d47.png) | ![image](https://user-images.githubusercontent.com/5148153/150705509-fa54fa9c-cfd0-4508-8999-19a3a434081c.png) | ![image](https://user-images.githubusercontent.com/5148153/150705545-86016087-62e4-4588-a6e2-43deaa330e36.png) |

