### PR TITLE
 Use wrap() to patch reviewer methods for compatibility with other add-ons

### DIFF
--- a/fill-the-blanks/src/handler.py
+++ b/fill-the-blanks/src/handler.py
@@ -88,6 +88,8 @@ class TypeClozeHander:
         if fld.startswith("cloze:"):
             clozeIdx = cCard.ord + 1
             fld = fld.split(":")[1]
+        else:
+            return original_typeAnsQuestionFilter(buf)
 
         for f in cCard.model()['flds']:
             if f['name'] == fld:


### PR DESCRIPTION
I'm writing an add-on that also patches typeAnsQuestionFilter to modify the behavior of the `{{type:fieldName}}` filter. It doesn't play nicely with the Fill the blanks add-on. My understanding (from a quick look at the code) is that your add-on doesn't need to modify plain `{{type:fieldName}}` filters, so I think it's safer to fall back to the original typeAnsQuestionFilter as early as possible when `cloze:` is not found. ~This solves the compatibility issue with my add-on.~