### PR TITLE
Support escapable HTML within cloze value

### DIFF
--- a/fill-the-blanks/src/handler.py
+++ b/fill-the-blanks/src/handler.py
@@ -234,7 +234,7 @@ class="ftb" style="width: {2}em" /><script type="text/javascript">setUpFillBlank
             given = ctx.answers[index] if ctx.answers and len(ctx.answers) == len(ctx.entries) else "None"
             field_res = self.format_field_result(given, cor)
             result = re.sub(r'<span class="?cloze\s*"?(\s*data-ordinal="\d\d?")?>%s</span>' % re.escape(field.value),
-                            field_res, result, 1)
+                            field_res.replace('\\', r'\\'), result, 1)
 
         # copy from reviewer original
         def repl(match):

--- a/fill-the-blanks/src/handler.py
+++ b/fill-the-blanks/src/handler.py
@@ -266,6 +266,7 @@ class="ftb" style="width: {2}em" /><script type="text/javascript">setUpFillBlank
         cor = re.sub("(\n|<br ?/?>|</?div>)+", " ", cor)
         cor = cor.replace("&nbsp;", " ")
         cor = cor.replace("\xa0", " ")
+        cor = cor.strip()
         return cor
 
     def _getTypedAnswer(self, _old) -> None:


### PR DESCRIPTION
Should fix issue #126 

- Support regex-reserved chars: use `re.escape` before merging the original cloze content into regex that replaces answer-side cloze span (`currentText`).
- Eliminate complex HTML stripping, unencoding, and re-encoding in the `clear_correct_value_as_reviewer` method.
  - **BeautifulSoup** already extracts content within a cloze `span` element as plain text.
  - Clarify `clear_correct_value_as_reviewer` method to expect BeautifulSoup-extracted span text content.
  - Simplify method to replace certain whitespace chars and elements.
  - **Need to run proposed code against existing tests to check whether all works as expected.**
- Include the cloze's original HTML content in `FieldState` class for reference when showing answers.
  - Store original cloze span content in `value` attribute (the value that will need to be found and replaced when generating HTML to show answer).
  - New `valueAsPlainText` attribute: clarify intent and simplify both matching and replacements.

Would you mind creating some unit tests using the following examples? Or, could you let me know how to set up a dev environment most easily so I can add the tests when I have time. In that case, do you use a Docker container, VS Code dev environment, or other env system I can quickly replicate?

**Example card HTML**

```html
<ul>
  <li>Test 1 correct answer input: `a to z and 0 to 9 only` -- {{c1::a to z and 0 to 9 only}}</li>
  <li>Test 2 correct answer input: `'single quotes' or "double quotes"` -- {{c2::'single quotes' or "double quotes"}}</li>
  <li>Test 3 correct answer input: `-, +, =` -- {{c3::-, +, =}}</li>
  <li>Test 4 correct answer input: `&lt;, &gt;, &amp;` -- {{c4::&lt;, &gt;, &amp;}}</li>
  <li>Test 5 correct answer input: `Formatting and link` -- {{c5::<b>Formatting</b> and <a href="https://www.google.com">link</a>}}</li>
  <li>Test 6 correct answer input: `Non-breaking space` -- {{c6::Non-breaking&nbsp;space}}</li>
</ul>
```

Test 4 correct answer input as plain text (what user types): `<, >, &`