### PR TITLE
Support zero-width space (\u200b) within cloze + minor fixes

### DIFF
--- a/fill-the-blanks/src/handler.py
+++ b/fill-the-blanks/src/handler.py
@@ -189,7 +189,7 @@ class TypeClozeHandler:
             item = """<input type="hidden" id="ansval%d" value="%s" />""" % (idx, val.replace('"', '&quot;'))
             item = item + """<input type="text" id="typeans{0}" placeholder="{1}"
 class="ftb" style="width: {2}em" /><script type="text/javascript">setUpFillBlankListener($('#ansval{0}').val(), {0})
-</script>""".format(idx, hint, self._getInputLength(hint, val))
+</script>""".format(idx, hint.replace('"', '&quot;'), self._getInputLength(hint, val))
             res = res.replace(self.CURRENT_CARD_FIELD_PLACEHOLDER, item, 1)
 
         if not self._currentFirst:

--- a/fill-the-blanks/src/handler.py
+++ b/fill-the-blanks/src/handler.py
@@ -57,6 +57,7 @@ class FieldState:
         self.hint = _hint
         self.valueAsPlainText = _valueAsPlainText
 
+
 class FieldsContext:
     answers: list = list()
 
@@ -266,6 +267,11 @@ class="ftb" style="width: {2}em" /><script type="text/javascript">setUpFillBlank
         cor = re.sub("(\n|<br ?/?>|</?div>)+", " ", cor)
         cor = cor.replace("&nbsp;", " ")
         cor = cor.replace("\xa0", " ")
+        # Remove zero-width space that might be used between double-colons as a
+        # hack to support double-colon content within cloze deletion (prevent
+        # hint split); users might add `&ZeroWidthSpace;` in HTML, which
+        # BeautifulSoup interprets as unicode `\u200b`:
+        cor = cor.replace("\u200b", "")
         cor = cor.strip()
         return cor
 

--- a/fill-the-blanks/src/handler.py
+++ b/fill-the-blanks/src/handler.py
@@ -139,7 +139,7 @@ class TypeClozeHandler:
                  self._formatHtmlContent(ref.typeCorrect) + \
                  buf[m.end():]
 
-    CURRENT_CARD_FIELD_PLACEHOLDER = "[...]"
+    CURRENT_CARD_FIELD_PLACEHOLDER = "[-multi-type-cloze-placeholder-]"
 
     def _createFieldsContext(self, txt, idx) -> FieldsContext:
         reCloze = re.compile(r"\{\{c%s::(.+?)\}\}" % idx, flags=re.DOTALL)


### PR DESCRIPTION
Support for a user-side "hack" that works around [this issue](https://forums.ankiweb.net/t/escaping-double-colon-in-cloze-deletion-cards/23966). Others have [asked elsewhere](https://www.reddit.com/r/Anki/comments/9diqax/is_there_a_way_to_escape_double_colons_inside_a/).

Ideally, Anki would allow some user-friendly way to include `::` within a cloze deletion to be interpreted as content instead of as a hint separator. Perhaps I'll contribute to Anki one day to enable that; I would propose `::::` be an escape sequence for literal `::` content. In the meantime, this enables the `fill-the-blanks` add-on to support another cloze feature that Anki core doesn't yet support.

__New unit test required__

Example HTML excerpt where that's needed (Ruby language syntax practice; IPv6 is another use case, and other popular programming languages sometimes require `::`):

```html
{{c1::Net:​&ZeroWidthSpace;:HTTP.get(uri)}}
```

Correct text input would be `Net::HTTP.get(uri)`.